### PR TITLE
feat: add support for browser to prevent exports not defined error

### DIFF
--- a/lib/validator.js
+++ b/lib/validator.js
@@ -18,5 +18,5 @@ function ThaiNationalID (id) {
 if (typeof window !== 'undefined') {
   export default ThaiNationalID
 } else {
-  module.exports = exports.default
+  module.exports = exports.default = ThaiNationalID
 }

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -1,6 +1,6 @@
 'use strict'
 
-export default function ThaiNationalID (id) {
+function ThaiNationalID (id) {
   if (!/^[0-9]{13}$/g.test(id)) {
     return false
   }
@@ -15,4 +15,8 @@ export default function ThaiNationalID (id) {
   return false
 }
 
-module.exports = exports.default
+if (typeof window !== 'undefined') {
+  export default ThaiNationalID
+} else {
+  module.exports = exports.default
+}


### PR DESCRIPTION
In brower environment, because of lack of `exports` variable, there will be errors `load component failed ReferenceError: exports is not defined`